### PR TITLE
Fix faulty .gitignore and add C .gitignore template

### DIFF
--- a/components/bms/SPITest/.gitignore
+++ b/components/bms/SPITest/.gitignore
@@ -1,4 +1,63 @@
 # Files and folders to be left untracked, ignored and left out by git
-/Drivers/ # HAL and CMSIS libraries
-/Debug/ # Compiled binaries, etc.
-/.settings/ # Eclipse project metadata
+
+# HAL and CMSIS libraries
+/Drivers/
+# Compiled binaries, etc.
+/Debug/
+# Eclipse project metadata
+/.settings/
+
+
+# Github C .gitignore template below
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf


### PR DESCRIPTION
Atom doesn't like comments on the same line as entries in a .gitignore.