### PR TITLE
BMS: Fix incorrect bit alignment in balancing driver

### DIFF
--- a/components/bms/bms_master/Core/Src/ltc6813_btm_bal.c
+++ b/components/bms/bms_master/Core/Src/ltc6813_btm_bal.c
@@ -18,6 +18,8 @@
 #define CFGBR0_DCC_BITS_BITMASK 0xF0U // Upper 4 bits of 1st byte
 #define CFGBR1_DCC_BITS_BITMASK 0x03U // Lowest 2 bits of 2nd byte
 
+#define CFGBR0_DCC_BITS_OFFSET 4
+
 /*============================================================================*/
 /* PUBLIC FUNCTION DEFINITIONS */
 
@@ -64,7 +66,7 @@ void BTM_BAL_setDischarge(Pack_t *pack, bool discharge_setting[PACK_NUM_BATTERY_
 
         // 1st byte of CFGRB - DCH setting for cell inputs 13-16
         BTM_data.cfgrb[device_num][0] &= ~CFGBR0_DCC_BITS_BITMASK;
-        BTM_data.cfgrb[device_num][0] |= (uint8_t) ((discharge_bitmask[device_num] >> 12) & CFGBR0_DCC_BITS_BITMASK);
+        BTM_data.cfgrb[device_num][0] |= (uint8_t) ((discharge_bitmask[device_num] >> (12 - CFGBR0_DCC_BITS_OFFSET)) & CFGBR0_DCC_BITS_BITMASK);
 
         // 2nd byte of CFGRB - DCH setting for cell inputs 17 and 18
         BTM_data.cfgrb[device_num][1] &= ~CFGBR1_DCC_BITS_BITMASK;


### PR DESCRIPTION
Where the DCC (discharge control) bits are for reference:

<img width="833" alt="image" src="https://github.com/UBC-Solar/firmware_v3/assets/55331709/26845af0-67f3-482a-83b4-3afd4c598396">
