### PR TITLE
Fix: Disable iwdg in DEBUG build

### DIFF
--- a/components/tel/Core/Src/freertos.c
+++ b/components/tel/Core/Src/freertos.c
@@ -225,7 +225,9 @@ void startDefaultTask(void const * argument)
   /* Infinite loop */
   for(;;)
   {
-    HAL_IWDG_Refresh(&hiwdg);
+    #ifdef DEBUG
+      HAL_IWDG_Refresh(&hiwdg);
+    #endif
     osDelay(DEFAULT_TASK_DELAY);
   }
   /* USER CODE END startDefaultTask */
@@ -250,7 +252,9 @@ void read_CAN_task(void const * argument)
     /* Wait for thread flags to be set in the CAN Rx FIFO0 Interrupt Callback */
     osSignalWait(CAN_READY, osWaitForever);
     
-    HAL_IWDG_Refresh(&hiwdg);
+    #ifdef DEBUG
+      HAL_IWDG_Refresh(&hiwdg);
+    #endif
     /*
      * Control Flow:
      * Wait for Flag from Interrupt

--- a/components/tel/Core/Src/freertos.c
+++ b/components/tel/Core/Src/freertos.c
@@ -225,7 +225,7 @@ void startDefaultTask(void const * argument)
   /* Infinite loop */
   for(;;)
   {
-    #ifdef DEBUG
+    #ifndef DEBUG
       HAL_IWDG_Refresh(&hiwdg);
     #endif
     osDelay(DEFAULT_TASK_DELAY);
@@ -252,7 +252,7 @@ void read_CAN_task(void const * argument)
     /* Wait for thread flags to be set in the CAN Rx FIFO0 Interrupt Callback */
     osSignalWait(CAN_READY, osWaitForever);
     
-    #ifdef DEBUG
+    #ifndef DEBUG
       HAL_IWDG_Refresh(&hiwdg);
     #endif
     /*

--- a/components/tel/Core/Src/iwdg.c
+++ b/components/tel/Core/Src/iwdg.c
@@ -31,7 +31,10 @@ void MX_IWDG_Init(void)
 {
 
   /* USER CODE BEGIN IWDG_Init 0 */
-
+  #ifdef DEBUG
+    // Do nothing if in debug mode. iwdg will reset the board if breakpoints are hit.
+    return;
+  #endif
   /* USER CODE END IWDG_Init 0 */
 
   /* USER CODE BEGIN IWDG_Init 1 */


### PR DESCRIPTION
iwdg resets the board when we use the debugger to pause or stop at breakpoints.
Added a preprocessor that disables the iwdg when using the debugger.