### PR TITLE
added heartbeat message

### DIFF
--- a/components/did/Core/Inc/DID.h
+++ b/components/did/Core/Inc/DID.h
@@ -100,3 +100,4 @@ void parse_can_message( uint8_t* CAN_rx_data, uint32_t CAN_ID );
 void update_DID_screen();
 void parse_warnings(uint8_t* CAN_rx_data);
 void DID_timeout();
+void send_did_heartbeat();

--- a/components/did/Core/Inc/DID.h
+++ b/components/did/Core/Inc/DID.h
@@ -22,6 +22,8 @@
 
 #define CAN_ID_SIMULATION_SPEED 0x750
 
+#define CAN_ID_HEARTBEAT 		0x580
+
 /*
  *	Cycle times (ms)
  */
@@ -60,6 +62,7 @@
 
 #define DID_REFRESH_DELAY		100	    // How often the DID will refresh the screen (ms)
 #define DID_PAGE_TIMEOUT        10000   // Time in ms until the DID changes back to the main page when on another page
+#define DID_HEARTBEAT_CYCLETIME 1000    // Time in ms between DID heartbeats
 
 #define NUM_PAGES 4
 #define PAGE_0 0

--- a/components/did/Core/Inc/can.h
+++ b/components/did/Core/Inc/can.h
@@ -33,8 +33,12 @@ extern "C" {
 /* USER CODE END Includes */
 
 extern CAN_HandleTypeDef hcan;
-
+extern CAN_TxHeaderTypeDef did_heartbeat_header;
+extern uint32_t can_mailbox;
 /* USER CODE BEGIN Private defines */
+
+#define DID_HEARTBEAT_ADDRESS 0x580
+#define DID_HEARTBEAT_DATA_LENGTH 2
 
 /* USER CODE END Private defines */
 

--- a/components/did/Core/Src/can.c
+++ b/components/did/Core/Src/can.c
@@ -23,6 +23,19 @@
 /* USER CODE BEGIN 0 */
 
 /**
+ * 	CAN message header for a the did_heartbeat
+ */
+// TODO: These should all probably be const
+CAN_TxHeaderTypeDef did_heartbeat_header = {
+    .StdId = DID_HEARTBEAT_ADDRESS,
+    .ExtId = 0x0000,
+    .IDE = CAN_ID_STD,
+    .RTR = CAN_RTR_DATA,
+    .DLC = DID_HEARTBEAT_DATA_LENGTH};
+
+uint32_t can_mailbox;
+
+/**
  * @brief Initialize CAN node for sending and receiving
  * @param: CAN filter structure
  * @retval: nothing

--- a/components/did/Core/Src/main.c
+++ b/components/did/Core/Src/main.c
@@ -167,7 +167,7 @@ int main(void)
 	// Update DID LCD screen
 	update_DID_screen();
 
-  
+  send_did_heartbeat();
 
     /* USER CODE END WHILE */
 

--- a/components/did/Core/Src/main.c
+++ b/components/did/Core/Src/main.c
@@ -167,6 +167,8 @@ int main(void)
 	// Update DID LCD screen
 	update_DID_screen();
 
+  
+
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */


### PR DESCRIPTION
MR adds a heartbeat message for the DID with CANID 0x580 and a cadence of 1000ms.
Message is 2 bytes long and consists of a uint16_t counter that is incremented with every message.