### PR TITLE
Packing messages as XBee API Frames

### DIFF
--- a/components/tel/Core/Inc/radio.h
+++ b/components/tel/Core/Inc/radio.h
@@ -14,6 +14,7 @@
 #include "can.h"
 #include "usart.h"
 #include "rtc.h"
+#include "xbee.h"
 
 /* RADIO BUFFER BYTE LENGTHS */
 #define CAN_BUFFER_LEN                      24
@@ -42,6 +43,17 @@
 
 /* TIMING CONSTANTS */
 #define CAN_TRANSMIT_TIMEOUT                1000                // 1 second timeout
+
+/*XBee API Packet CONSTANTS*/
+#define API_BUFFER_SIZE 300 //number of bytes in api_buffeer array
+#define API_PACKET_SIZE 10 //number of messages in each api packet
+#define API_OVERHEAD_SIZE 18 //number of bits in api Overhead
+
+
+
+
+
+
 
 void RADIO_tx_CAN_msg(CAN_Radio_msg_t *tx_CAN_msg);
 

--- a/components/tel/Core/Inc/radio.h
+++ b/components/tel/Core/Inc/radio.h
@@ -16,6 +16,7 @@
 #include "rtc.h"
 #include "xbee.h"
 
+
 /* RADIO BUFFER BYTE LENGTHS */
 #define CAN_BUFFER_LEN                      24
 #define GPS_MESSAGE_LEN                     200
@@ -45,9 +46,9 @@
 #define CAN_TRANSMIT_TIMEOUT                1000                // 1 second timeout
 
 /*XBee API Packet CONSTANTS*/
-#define API_BUFFER_SIZE 300 //number of bytes in api_buffeer array
-#define API_PACKET_SIZE 10 //number of messages in each api packet
-#define API_OVERHEAD_SIZE 18 //number of bits in api Overhead
+#define API_BUFFER_SIZE 					300 			    //number of bytes in api_buffer array
+#define API_MAX_MSGS  						10 					//number of messages in each api packet
+#define API_OVERHEAD_SIZE 					20 					//number of bytes in api Overhead
 
 
 

--- a/components/tel/Core/Inc/xbee.h
+++ b/components/tel/Core/Inc/xbee.h
@@ -11,35 +11,41 @@
 #define INC_XBEE_H_
 
 #include <stdint.h>
+#include <radio.h>
 
 /*XBee API Packet Overhead*/
-#define START_DELIMITER 0x7E
-#define FRAME_TYPE 0x10
-#define FRAME_ID 0x01
-#define BIT_ADDRESS_16_LOW 0xFE
-#define BIT_ADDRESS_16_HIGH 0xFE
-#define BROADCAST_RADIUS 0x00
-#define OPTIONS 0x00
-#define TYPE 0x00
-#define BIT_ADDRESS_16_LOW 0xFE
-#define BIT_ADDRESS_16_HIGH 0xFE
+#define START_DELIMITER 					0x7E
+#define FRAME_TYPE 							0x10 				//0x10 is a transmit request
+#define FRAME_ID 							0x01
+#define BIT_ADDRESS_16_LOW 					0xFE
+#define BIT_ADDRESS_16_HIGH 				0xFE
+#define BROADCAST_RADIUS 					0x00
+#define OPTIONS 							0x00
+#define TYPE 								0x00
+#define BIT_ADDRESS_16_LOW 					0xFE
+#define BIT_ADDRESS_16_HIGH 				0xFE
+#define CAN_TYPE 							0x00
 
-#define CHECKSUM_LENGTH_SIZE 4 //size of fields in api packet that are excluded in checksum and length field calculations
+/*XBEE API PACKET Calculation Constants*/
+#define MASK_8_BITS 						0xFF
+#define UINT8_MAX_SIZE 						0xFF
+#define BIT_ADDRESS_64_LENGTH 				8
+#define CHECKSUM_LENGTH_SIZE 				4					//size of fields in api packet that are excluded in checksum and length field calculations
 
 /*XBee API Packet Positions*/
-#define START_DELIMITER_POSITION 0
-#define MSB_POSITION 1
-#define LSB_POSITION 2
-#define FRAME_TYPE_POSITION 3
-#define FRAME_ID_POSITION 4
-#define BIT_ADDRESS_64_START_POSITION 5
-#define BIT_ADDRESS_16_LOW_POSITION 13
-#define BIT_ADDRESS_16_HIGH_POSITION 14
-#define BROADCAST_RADIUS_POSITION 15
-#define OPTIONS_POSITION 16
-#define TYPE_POSITION 17
-#define LENGTH_POSITION 18
-#define MESSAGE_DATA_START_POSITION 19
+#define START_DELIMITER_POSITION 			0
+#define MSB_POSITION 						1
+#define LSB_POSITION 						2
+#define FRAME_TYPE_POSITION 				3
+#define FRAME_ID_POSITION 					4
+#define BIT_ADDRESS_64_START_POSITION 		5
+#define BIT_ADDRESS_16_LOW_POSITION 		13
+#define BIT_ADDRESS_16_HIGH_POSITION 		14
+#define BROADCAST_RADIUS_POSITION 			15
+#define OPTIONS_POSITION 					16
+#define TYPE_POSITION 						17
+#define LENGTH_POSITION 					18
+#define MESSAGE_DATA_START_POSITION 		19
 
 
 

--- a/components/tel/Core/Inc/xbee.h
+++ b/components/tel/Core/Inc/xbee.h
@@ -1,0 +1,50 @@
+
+/**
+ *  @file xbee.h
+ *  @brief header file for xbee.c. Define xBee API packet positions
+ *
+ *  @date 2024/06/16
+ *  @author Evan Owens
+ *   */
+
+#ifndef INC_XBEE_H_
+#define INC_XBEE_H_
+
+#include <stdint.h>
+
+/*XBee API Packet Overhead*/
+#define START_DELIMITER 0x7E
+#define FRAME_TYPE 0x10
+#define FRAME_ID 0x01
+#define BIT_ADDRESS_16_LOW 0xFE
+#define BIT_ADDRESS_16_HIGH 0xFE
+#define BROADCAST_RADIUS 0x00
+#define OPTIONS 0x00
+#define TYPE 0x00
+#define BIT_ADDRESS_16_LOW 0xFE
+#define BIT_ADDRESS_16_HIGH 0xFE
+
+#define CHECKSUM_LENGTH_SIZE 4 //size of fields in api packet that are excluded in checksum and length field calculations
+
+/*XBee API Packet Positions*/
+#define START_DELIMITER_POSITION 0
+#define MSB_POSITION 1
+#define LSB_POSITION 2
+#define FRAME_TYPE_POSITION 3
+#define FRAME_ID_POSITION 4
+#define BIT_ADDRESS_64_START_POSITION 5
+#define BIT_ADDRESS_16_LOW_POSITION 13
+#define BIT_ADDRESS_16_HIGH_POSITION 14
+#define BROADCAST_RADIUS_POSITION 15
+#define OPTIONS_POSITION 16
+#define TYPE_POSITION 17
+#define LENGTH_POSITION 18
+#define MESSAGE_DATA_START_POSITION 19
+
+
+
+void XBEE_api_overhead_setup(uint8_t api_packet[]);
+void XBEE_calculate_checksum(uint8_t api_packet[], uint16_t packet_length);
+void XBEE_calculate_length(uint8_t api_packet[], uint16_t packet_length);
+
+#endif /* INC_XBEE_H_ */

--- a/components/tel/Core/Src/radio.c
+++ b/components/tel/Core/Src/radio.c
@@ -102,15 +102,15 @@ void RADIO_tx_API_Packager(uint8_t api_buffer[], uint16_t api_buffer_position)
 */
 void RADIO_tx_API_Accumulator(uint8_t radio_message[])
 {
-  int i;
-  for (i = 0; i<CAN_BUFFER_LEN; i++){
+
+  for (int i = 0; i<CAN_BUFFER_LEN; i++){
 	  api_buffer[i+api_buffer_position] = radio_message[i];
   }
 
   api_message_count++;
-  api_buffer_position = api_buffer_position + i;
+  api_buffer_position = api_buffer_position + CAN_BUFFER_LEN;
 
-  if (api_message_count == API_PACKET_SIZE){
+  if (api_message_count == API_MAX_MSGS){
 	  RADIO_tx_API_Packager(api_buffer, api_buffer_position);
 	  api_message_count = 0;
 	  api_buffer_position = 0;

--- a/components/tel/Core/Src/radio.c
+++ b/components/tel/Core/Src/radio.c
@@ -73,8 +73,8 @@ static void copy_CAN_id(uint8_t* source, CAN_Radio_msg_t *tx_CAN_msg, uint32_t c
 
 
 /**
- * @brief Takes CAN radio buffer and adds it to an API Packet Array. Once enough messages are in the array, array is transmitted.
- * @param radio_buffer[]: pointer to an array in which the messages are being added.
+ * @brief Takes api_buffer and packages it into an api frame. transmits this api frame over uart.
+ * @param radio_buffer[]: pointer to an array in which the messages are being added, api_buffer_postion: position in api_buffer where messages end.
  * @return void
 */
 void RADIO_tx_API_Packager(uint8_t api_buffer[], uint16_t api_buffer_position)
@@ -96,7 +96,7 @@ void RADIO_tx_API_Packager(uint8_t api_buffer[], uint16_t api_buffer_position)
 
 
 /**
- * @brief Takes CAN radio buffer and adds it to an API Packet Array. Once enough messages are in the array, array is transmitted.
+ * @brief Takes CAN radio buffer and adds it to an API buffer Array. Once enough messages are in the array, array is sent for packaging.
  * @param radio_buffer[]: pointer to an array in which the messages are being added.
  * @return void
 */

--- a/components/tel/Core/Src/xbee.c
+++ b/components/tel/Core/Src/xbee.c
@@ -11,7 +11,8 @@
 
 
 /**
- * @brief Adds up all the bytes after length and before checksum in an api packet
+ * @brief Adds up all the bytes after length and before checksum in an api packet. Packet_length-1 is the final position in the api_packet,
+ * and will contain checksums, so we exclude it when adding up bytes.
  *
  * @param api packet: api packet array
  * @return uint16_t total_bytes in api packet before checksum and after length fields
@@ -20,7 +21,7 @@
 uint16_t XBEE_sum_bytes (uint8_t api_packet[], uint16_t packet_length)
 {
   uint16_t total_bytes = 0;
-  for (int i = FRAME_TYPE_POSITION; i < packet_length-2; i++){
+  for (int i = FRAME_TYPE_POSITION; i < packet_length -1; i++){
 		 total_bytes += api_packet[i];
   }
   return total_bytes;
@@ -88,7 +89,7 @@ void XBEE_calculate_checksum(uint8_t api_packet[], uint16_t packet_length)
  uint16_t total_bytes = XBEE_sum_bytes(api_packet, packet_length);
  uint16_t checksum;
  checksum = UINT8_MAX_SIZE - (total_bytes & MASK_8_BITS);
- api_packet[packet_length-1] = checksum;
+ api_packet[packet_length-1] = checksum; //packet_length -1 is final position in api_packet array
 
 }
 

--- a/components/tel/Core/Src/xbee.c
+++ b/components/tel/Core/Src/xbee.c
@@ -1,0 +1,87 @@
+/**
+ *  @file xbee.c
+ *  @brief Defines functions related to xBee module, including setting up xBee packet overhead, and handling return frames
+ *
+ *  @date 2024/06/16
+ *  @author Evan Owens
+ */
+
+#include "xbee.h"
+#include <math.h>
+
+/**
+ * @brief Adds up all the bytes after length and before checksum in an api packet
+ *
+ * @param api packet: api packet array
+ * @return uint16_t total_bytes in api packet before checksum and after length fields
+*/
+
+uint16_t XBEE_sum_bytes (uint8_t api_packet[], uint16_t packet_length)
+{
+  uint16_t total_bytes = 0;
+  for (int i = 3; i < packet_length; i++){
+		 total_bytes += api_packet[i];
+  }
+  return total_bytes;
+}
+
+
+/**
+ * @brief Sets up overhead for an API Packet
+ *
+ * @param api packet: api packet array
+ * @return api_packet with setup api overhead
+*/
+void XBEE_api_overhead_setup(uint8_t api_packet[])
+{
+  uint8_t bit_address_64[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00};
+
+  api_packet[START_DELIMITER_POSITION] = START_DELIMITER;
+  api_packet[FRAME_TYPE_POSITION] = FRAME_TYPE;
+  api_packet[FRAME_ID_POSITION] = FRAME_ID;
+  api_packet[BIT_ADDRESS_16_LOW_POSITION] = BIT_ADDRESS_16_LOW;
+  api_packet[BIT_ADDRESS_16_HIGH_POSITION] = BIT_ADDRESS_16_HIGH;
+  api_packet[BROADCAST_RADIUS_POSITION] = BROADCAST_RADIUS;
+  api_packet[OPTIONS_POSITION] = OPTIONS;
+
+  for (int i =0; i < 8; i++){
+	  api_packet[i] = bit_address_64[i];
+  }
+
+}
+
+
+/**
+ * @brief Calculates and adds the MSB and LSB for an API packet
+ *
+ * @param api packet: api packet array
+ * @return api_packet with setup length fields
+*/
+void XBEE_calculate_length(uint8_t api_packet[], uint16_t packet_length)
+{
+ uint16_t total_bytes = packet_length - CHECKSUM_LENGTH_SIZE;
+ uint16_t lsb;
+ uint16_t msb;
+ lsb = total_bytes % 256;
+ msb = (uint16_t)(floor(total_bytes /256));
+ api_packet[MSB_POSITION] = msb;
+ api_packet[LSB_POSITION] = lsb;
+}
+
+
+
+/**
+ * @brief Calculates the checksum of an api frame and adds it to the api_packet
+ *
+ * @param api packet: api packet array
+ * @return api_packet with setup checksum field
+*/
+void XBEE_calculate_checksum(uint8_t api_packet[], uint16_t packet_length)
+{
+ uint16_t total_bytes = XBEE_sum_bytes(api_packet, packet_length);
+ uint16_t checksum;
+ checksum = 255 - (total_bytes & 255);
+ api_packet[packet_length] = checksum;
+
+}
+


### PR DESCRIPTION
As part of implementing api_packaging, I made the following changes:

1. Added RADIO_tx_API_Accumulator function. This function takes radio_buffers (can messages) from RADIO_tx_CAN_msg and stores them in an api_buffer.

2. Added RADIO_tx_API_Packager function. Once a set amount of can messages are in an api_buffer, this function is called, packages all the can messages in the api_buffer, and transmits the api_package over uart.

3. Added Xbee.c and .h files. Xbee.c contains functions for packaging xbee api packages, (and in the future, handling any return statuses, and perhaps AT commands). Xbee.c contains solely functions proprietary to the xbee api packaging process - that is, if we ever switch radio module brands, this file could be removed and replaced with a different file, and the rest of radio.c would be largely untouched.

4. Some things xbee.c does right now is calculate checksum, and length fields, as well as set up the static api overhead (destination addresses, etc).
I have not yet tested my changes, but I will do so soon in a standalone file. Let me know what you guys think.