### PR TITLE
[Draft] Feat: MCB timeout for MDI

### DIFF
--- a/components/mdi/Core/Inc/can.h
+++ b/components/mdi/Core/Inc/can.h
@@ -46,6 +46,7 @@ typedef struct
 	bool PWR_mode_on;
 	bool regen;
 	bool cruise_control_enable;
+	uint32_t last_rx_time;
 
 	//0x501
 	uint8_t motorCurrentFlag;

--- a/components/mdi/Core/Src/can.c
+++ b/components/mdi/Core/Src/can.c
@@ -19,6 +19,8 @@
 */
 void CAN_Decode_Velocity_Message(uint8_t localRxData[], CAN_message_t* CAN_msg)
 {
+	// Update the last rx time
+	CAN_msg->last_rx_time = HAL_GetTick();
 
 	union { //union struct to convert the input stream of 32-bits into IEEE float
 		uint32_t concatenated_bits;

--- a/components/mdi/Core/Src/main.c
+++ b/components/mdi/Core/Src/main.c
@@ -329,7 +329,9 @@ int main(void)
         TxHeader.StdId = MDI_DIAGNOSTICS_CAN_ID;
         TxHeader.IDE = CAN_ID_STD;
         TxHeader.DLC = 1;
-        TxData[0] = 0; // Clear TxData[0]
+        for(int i = 0; i < 8; i++){   // Clear TxData
+          TxData[i] = 0;
+        }
 
         if(1 == mcb_communication_fault)
         {

--- a/components/mdi/Core/Src/main.c
+++ b/components/mdi/Core/Src/main.c
@@ -42,6 +42,9 @@
 #define DAC_REGEN_ADDR  (0b0001101 << 1) //I2C address for the regen DAC
 
 #define MCB_COMMUNICATION_TIMEOUT 500 // Time in ms to wait for a motor command from MCB before setting a fault
+#define MDI_DIAGNOSTICS_CAN_ID 0x50F // CAN ID for MDI diagnostics message
+
+#define SETBIT(x, bitpos) (x |= (1 << bitpos))
 /* USER CODE END PM */
 
 /* Private variables ---------------------------------------------------------*/
@@ -321,6 +324,34 @@ int main(void)
     		}
     		HAL_CAN_AddTxMessage(&hcan, &TxHeader, TxData, TxMailbox);
     		SendSlowMessage = 0;
+
+        // MDI diagnostics 0x50F
+        TxHeader.StdId = MDI_DIAGNOSTICS_CAN_ID;
+        TxHeader.IDE = CAN_ID_STD;
+        TxHeader.DLC = 1;
+        TxData[0] = 0; // Clear TxData[0]
+
+        if(1 == mcb_communication_fault)
+        {
+          SETBIT(TxData[0], 0);
+        }
+
+        if(FORWARD_TRUE == msg0.FWD_direction)
+        {
+          SETBIT(TxData[0], 1);
+        }
+
+        if(POWER_MODE_ON == msg0.PWR_mode_on)
+        {
+          SETBIT(TxData[0], 2);
+        }
+
+        if(REGEN_TRUE == msg0.regen)
+        {
+          SETBIT(TxData[0], 3);
+        }
+
+        HAL_CAN_AddTxMessage(&hcan, &TxHeader, TxData, TxMailbox);
       }
     	SendMessageTimerInterrupt = 0;
     }


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
Added mcb communication fault if mdi does not receive a motor command from the mcb in >500ms.  
mdi will send `0.0f` acceleration and `0.0f` regen to mdu if mcb comm fault is triggered

## Monday Link
<!-- Copy related Monday issue here -->
N/A

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DID
- [ ] ECU
- [ ] MCB
- [X] MDI
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->
needs testing

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->