### PR TITLE
Fix: Removed mech brake checks [don't merge]

### DIFF
--- a/components/mcb/Core/Src/mcb.c
+++ b/components/mcb/Core/Src/mcb.c
@@ -127,10 +127,6 @@ void send_mcb_githash()
 
 MotorCommand DoStateDRIVE( InputFlags input_flags )
 {
-	// Check if mech brake is pressed
-	if ( input_flags.mech_brake_pressed )
-		return GetMotorCommand(0.0, VELOCITY_REGEN_DISABLED);
-
 	// Check if regen is enabled
 	if (input_flags.regen_enabled) // regen switch on and battery isn't requesting regen to be turned off
 	{
@@ -144,28 +140,24 @@ MotorCommand DoStateDRIVE( InputFlags input_flags )
 
 void TransitionDRIVEstate( InputFlags input_flags, DriveState * state)
 {
-	if( input_flags.switch_pos_reverse && input_flags.velocity_under_threshold && input_flags.mech_brake_pressed)
+	if( input_flags.switch_pos_reverse && input_flags.velocity_under_threshold)
 		*state = REVERSE;
-	else if( input_flags.switch_pos_park && input_flags.velocity_under_threshold && input_flags.mech_brake_pressed)
+	else if( input_flags.switch_pos_park && input_flags.velocity_under_threshold)
 		*state = PARK;
 }
 
 
 MotorCommand DoStateREVERSE(InputFlags input_flags)
 {
-	// Check if mech brake is pressed
-	if ( input_flags.mech_brake_pressed )
-		return GetMotorCommand(0.0, VELOCITY_REGEN_DISABLED);
-
 	// Regen disabled in reverse on MDI, dont need to check input_flags.regen_enabled
 	return GetMotorCommand(g_throttle, VELOCITY_REVERSE);
 }
 
 void TransitionREVERSEstate(InputFlags input_flags, DriveState * state)
 {
-	if ( input_flags.switch_pos_drive && input_flags.velocity_under_threshold && input_flags.mech_brake_pressed)
+	if ( input_flags.switch_pos_drive && input_flags.velocity_under_threshold)
 		*state = DRIVE;
-	else if ( input_flags.switch_pos_park && input_flags.velocity_under_threshold && input_flags.mech_brake_pressed)
+	else if ( input_flags.switch_pos_park && input_flags.velocity_under_threshold)
 		*state = PARK;
 }
 
@@ -176,9 +168,9 @@ MotorCommand DoStatePARK()
 
 void TransitionPARKstate(InputFlags input_flags, DriveState * state)
 {
-	if ( input_flags.switch_pos_drive && input_flags.velocity_under_threshold && input_flags.mech_brake_pressed )
+	if ( input_flags.switch_pos_drive && input_flags.velocity_under_threshold)
 		*state = DRIVE;
-	else if ( input_flags.switch_pos_reverse && input_flags.velocity_under_threshold && input_flags.mech_brake_pressed)
+	else if ( input_flags.switch_pos_reverse && input_flags.velocity_under_threshold)
 		*state = REVERSE;
 }
 


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
This PR is for comp if there are mech brake switch issues.
Disables checks on the mech brake, but still updates the mech brake pressed on the MCB diagnostics message.

## Monday Link
<!-- Copy related Monday issue here -->
N/A

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DID
- [ ] ECU
- [X] MCB
- [ ] MDI
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [X] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [X] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->