### PR TITLE
Backstop added to pedal so adjusting the max value

### DIFF
--- a/components/mcb/Core/Inc/mcb.h
+++ b/components/mcb/Core/Inc/mcb.h
@@ -61,7 +61,7 @@
  */
 #define ADC_LOWER_DEADZONE            900
 #define ADC_FOR_NO_SPIN               1300    
-#define ADC_MIN_FOR_FULL_THROTTLE     2000
+#define ADC_MIN_FOR_FULL_THROTTLE     1850
 #define ADC_MAX_FOR_FULL_THROTTLE     2600
 
 #define SETBIT(x, bitpos) (x |= (1 << bitpos))


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
Backstop was added to the accel pedal during comp. Adjusting the max ADC reading here for full throttle. Below is images of the data we got for the full and no pedal press.

![IMG_3361-min](https://github.com/user-attachments/assets/19d7cf9e-867a-435c-86ea-2c4c01c0916a)
![IMG_3362-min](https://github.com/user-attachments/assets/92d2d1f1-913a-47d1-b244-be3a58783d63)


## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DID
- [ ] ECU
- [x] MCB
- [ ] MDI
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DID
- [ ] ECU
- [x] MCB
- [ ] MDI
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->