### PR TITLE
Fix: MCB Throttle Bounds Modified

### DIFF
--- a/components/mcb/Core/Inc/mcb.h
+++ b/components/mcb/Core/Inc/mcb.h
@@ -61,8 +61,8 @@
  */
 #define ADC_LOWER_DEADZONE            900
 #define ADC_FOR_NO_SPIN               1300    
-#define ADC_MIN_FOR_FULL_THROTTLE     2000
-#define ADC_MAX_FOR_FULL_THROTTLE     2600
+#define ADC_MIN_FOR_FULL_THROTTLE     1850
+#define ADC_MAX_FOR_FULL_THROTTLE     4000
 
 #define SETBIT(x, bitpos) (x |= (1 << bitpos))
 #define GETBIT(x, bitpos) ((x >> bitpos) & 1)


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
See original PR: https://github.com/UBC-Solar/firmware_v3/pull/150

Max throttle short increased to 4000 to reduce impact of spiked ADC values resulting in (0,0) being sent. 

This is flashed on the car and verified that car drives.

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DID
- [ ] ECU
- [x] MCB
- [ ] MDI
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->