### PR TITLE
Feat: Added CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS
+
+# embd exec gets notifications for everything
+* @UBC-Solar/embd_exec
+
+# embd sub team get notified about everything but bms and ecu
+* @UBC-Solar/embd
+


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
Added approval groups for the embd team and the embd exec team (leads + saman). This way whenever someone makes a PR we can choose to added these groups as required reviewers and get these benefits
* All embedded members are **aware** of changes happening to the repo
* All embedded members have the opportunity to learn how to give feedback on and criticize code.

## Monday Link
<!-- Copy related Monday issue here -->
https://ubcsolar.monday.com/boards/7156006167/pulses/7266193005/posts/3392935200

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DID
- [ ] ECU
- [ ] MCB
- [ ] MDI
- [ ] TEL
- [x] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

Tested if this PR works. I added embd + embd_exec groups as reviewers
![image](https://github.com/user-attachments/assets/dff8de05-1741-4326-96fe-8bf82bb3d900)
Ideally we want everyone in these groups to be notified and the moment one approval from each is given I can merge it. 

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->