### PR TITLE
fixed codeowners for embd so only tel, amb, mcb, did

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # CODEOWNERS
 
 # embd exec gets notifications for everything
-* @UBC-Solar/embd_exec
-
-# embd sub team get notified about everything but bms and ecu
-* @UBC-Solar/embd
+/components/tel  @embd_exec @embd
+/components/did  @embd_exec @embd
+/components/mcb  @embd_exec @embd
+/components/amb  @embd_exec @embd
 


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
Previously, EMBD still got pinged for bms and ecu changes.

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DID
- [ ] ECU
- [ ] MCB
- [ ] MDI
- [ ] TEL
- [x] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

Confirmed new PRs did not require embd
<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->