### PR TITLE
Feat: Multiplexed Messages in CAN bus Simultation Script 

### DIFF
--- a/tools/Simulate_CAN_Bus/can_messages.yaml
+++ b/tools/Simulate_CAN_Bus/can_messages.yaml
@@ -1,185 +1,216 @@
-- ID: "0x701"
-  interval: 250
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 600
+# - ID: "0x701"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1         # Only affected by multiplexed messages which send quickly in a burst
+#   board_delay: 600
 
-- ID: "0x702"
-  interval: 250
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 600
+# - ID: "0x702"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 600
 
-- ID: "0x703"
-  interval: 250
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 600
+# - ID: "0x703"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 600
 
 - ID: "0x622"
   interval: 1000
   data: "00000000000000"
   dlc: 7
+  num_msgs_sent_in_burst: 1  
   board_delay: 0
 
 - ID: "0x623"
   interval: 1000
   data: "000000000000"
   dlc: 6
+  num_msgs_sent_in_burst: 1  
   board_delay: 0
 
 - ID: "0x624"
   interval: 1000
   data: "00000000000000"
   dlc: 7
+  num_msgs_sent_in_burst: 1  
   board_delay: 0
 
 - ID: "0x625"
   interval: 1000
   data: "0000000000"
   dlc: 5
+  num_msgs_sent_in_burst: 1  
   board_delay: 0
 
 - ID: "0x626"
   interval: 1000
   data: "0000000000"
   dlc: 5
+  num_msgs_sent_in_burst: 8         # 8 multiplexed messages sent in a burst
   board_delay: 0
 
 - ID: "0x627"
   interval: 1000
   data: "0000000000"
   dlc: 5
+  num_msgs_sent_in_burst: 8  
   board_delay: 0
 
 - ID: "0x628"
   interval: 1000
   data: "0000000000"
   dlc: 5
+  num_msgs_sent_in_burst: 8
   board_delay: 0
 
 - ID: "0x629"
   interval: 1000
   data: "00000000"
   dlc: 4
+  num_msgs_sent_in_burst: 1
   board_delay: 0
 
 - ID: "0x450"
   interval: 200
   data: "0000000000000000"
   dlc: 6
+  num_msgs_sent_in_burst: 1  
   board_delay: 0
 
-- ID: "0x1806E5F4"
-  interval: 1000
-  data: "000000000000000000"
-  dlc: 8
-  board_delay: 0
+# - ID: "0x1806E5F4"
+#   interval: 1000
+#   data: "000000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
 
-- ID: "0x18FF50E5"
-  interval: 1000
-  data: "000000000000000000"
-  dlc: 8
-  board_delay: 0
+# - ID: "0x18FF50E5"
+#   interval: 1000
+#   data: "000000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
 
-- ID: "0x501"
-  interval: 200
-  data: "000000000000000000"
-  dlc: 8
-  board_delay: 500
+# - ID: "0x501"
+#   interval: 200
+#   data: "000000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 500
 
-- ID: "0x502"
-  interval: 200
-  data: "000000000000000000"
-  dlc: 8
-  board_delay: 500
+# - ID: "0x502"
+#   interval: 200
+#   data: "000000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 500
 
-- ID: "0x503"
-  interval: 200
-  data: "000000000000000000"
-  dlc: 8
-  board_delay: 500
+# - ID: "0x503"
+#   interval: 200
+#   data: "000000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 500
 
-- ID: "0x50B"
-  interval: 1000
-  data: "000000000000000000"
-  dlc: 8
-  board_delay: 500
+# - ID: "0x50B"
+#   interval: 1000
+#   data: "000000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 500
 
-- ID: "0x50F"
-  interval: 200
-  data: "000000000000000000"
-  dlc: 8
-  board_delay: 500
+# - ID: "0x50F"
+#   interval: 200
+#   data: "000000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 500
 
-- ID: "0x08F89540"
-  interval: 200
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 0
+# - ID: "0x08F89540"
+#   interval: 200
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
 
-- ID: "0x08850225"
-  interval: 200
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 0
+# - ID: "0x08850225"
+#   interval: 200
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
 
-- ID: "0x08A50225"
-  interval: 200
-  data: "00000000"
-  dlc: 8
-  board_delay: 0
+# - ID: "0x08A50225"
+#   interval: 200
+#   data: "00000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
 
-- ID: "0x401"
-  interval: 50
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 400
+# - ID: "0x401"
+#   interval: 50
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 400
 
-- ID: "0x403"
-  interval: 100
-  data: "000000"
-  dlc: 3
-  board_delay: 400
+# - ID: "0x403"
+#   interval: 100
+#   data: "000000"
+#   dlc: 3
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 400
 
-- ID: "0x404"
-  interval: 100
-  data: "00000000"
-  dlc: 3
-  board_delay: 400
+# - ID: "0x404"
+#   interval: 100
+#   data: "00000000"
+#   dlc: 3
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 400
 
-- ID: "0x405"
-  interval: 10000
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 400
+# - ID: "0x405"
+#   interval: 10000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 400
 
-- ID: "0x300"
-  interval: 1000
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 200
+# - ID: "0x300"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 200
 
-- ID: "0x750"
-  interval: 1000
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 100
+# - ID: "0x750"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 100
 
-- ID: "0x752"
-  interval: 500
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 100
+# - ID: "0x752"
+#   interval: 500
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 100
 
-- ID: "0x753"
-  interval: 500
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 100
+# - ID: "0x753"
+#   interval: 500
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 100
 
-- ID: "0x754"
-  interval: 500
-  data: "0000000000000000"
-  dlc: 8
-  board_delay: 100
+# - ID: "0x754"
+#   interval: 500
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 100

--- a/tools/Simulate_CAN_Bus/can_messages.yaml
+++ b/tools/Simulate_CAN_Bus/can_messages.yaml
@@ -1,23 +1,23 @@
-# - ID: "0x701"
-#   interval: 250
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1         # Only affected by multiplexed messages which send quickly in a burst
-#   board_delay: 600
+- ID: "0x701"
+  interval: 250
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1         # Only affected by multiplexed messages which send quickly in a burst
+  board_delay: 600
 
-# - ID: "0x702"
-#   interval: 250
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 600
+- ID: "0x702"
+  interval: 250
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 600
 
-# - ID: "0x703"
-#   interval: 250
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 600
+- ID: "0x703"
+  interval: 250
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 600
 
 - ID: "0x622"
   interval: 1000
@@ -82,135 +82,135 @@
   num_msgs_sent_in_burst: 1  
   board_delay: 0
 
-# - ID: "0x1806E5F4"
-#   interval: 1000
-#   data: "000000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 0
+- ID: "0x1806E5F4"
+  interval: 1000
+  data: "000000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 0
 
-# - ID: "0x18FF50E5"
-#   interval: 1000
-#   data: "000000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 0
+- ID: "0x18FF50E5"
+  interval: 1000
+  data: "000000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 0
 
-# - ID: "0x501"
-#   interval: 200
-#   data: "000000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 500
+- ID: "0x501"
+  interval: 200
+  data: "000000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 500
 
-# - ID: "0x502"
-#   interval: 200
-#   data: "000000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 500
+- ID: "0x502"
+  interval: 200
+  data: "000000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 500
 
-# - ID: "0x503"
-#   interval: 200
-#   data: "000000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 500
+- ID: "0x503"
+  interval: 200
+  data: "000000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 500
 
-# - ID: "0x50B"
-#   interval: 1000
-#   data: "000000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 500
+- ID: "0x50B"
+  interval: 1000
+  data: "000000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 500
 
-# - ID: "0x50F"
-#   interval: 200
-#   data: "000000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 500
+- ID: "0x50F"
+  interval: 200
+  data: "000000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 500
 
-# - ID: "0x08F89540"
-#   interval: 200
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 0
+- ID: "0x08F89540"
+  interval: 200
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 0
 
-# - ID: "0x08850225"
-#   interval: 200
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 0
+- ID: "0x08850225"
+  interval: 200
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 0
 
-# - ID: "0x08A50225"
-#   interval: 200
-#   data: "00000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 0
+- ID: "0x08A50225"
+  interval: 200
+  data: "00000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 0
 
-# - ID: "0x401"
-#   interval: 50
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 400
+- ID: "0x401"
+  interval: 50
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 400
 
-# - ID: "0x403"
-#   interval: 100
-#   data: "000000"
-#   dlc: 3
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 400
+- ID: "0x403"
+  interval: 100
+  data: "000000"
+  dlc: 3
+  num_msgs_sent_in_burst: 1  
+  board_delay: 400
 
-# - ID: "0x404"
-#   interval: 100
-#   data: "00000000"
-#   dlc: 3
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 400
+- ID: "0x404"
+  interval: 100
+  data: "00000000"
+  dlc: 3
+  num_msgs_sent_in_burst: 1  
+  board_delay: 400
 
-# - ID: "0x405"
-#   interval: 10000
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 400
+- ID: "0x405"
+  interval: 10000
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 400
 
-# - ID: "0x300"
-#   interval: 1000
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 200
+- ID: "0x300"
+  interval: 1000
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 200
 
-# - ID: "0x750"
-#   interval: 1000
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 100
+- ID: "0x750"
+  interval: 1000
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 100
 
-# - ID: "0x752"
-#   interval: 500
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 100
+- ID: "0x752"
+  interval: 500
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 100
 
-# - ID: "0x753"
-#   interval: 500
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 100
+- ID: "0x753"
+  interval: 500
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 100
 
-# - ID: "0x754"
-#   interval: 500
-#   data: "0000000000000000"
-#   dlc: 8
-#   num_msgs_sent_in_burst: 1  
-#   board_delay: 100
+- ID: "0x754"
+  interval: 500
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 100


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
The CAN Bus simulation script inside the tools of this repository did not have support for multiplexed messages like 0x626-0x628. These messages are sent in bursts of 8 every second

## Monday Link
<!-- Copy related Monday issue here -->
https://ubcsolar26.monday.com/boards/7524367653/pulses/7716158340/posts/3588714436

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DID
- [ ] ECU
- [ ] MCB
- [ ] MDI
- [ ] TEL
- [ ] CI/CD
- [x] tools


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->
Send messages over PCAN to TEL board and observed send count.

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->