### PR TITLE
FIX: fixed hazard light logic

### DIFF
--- a/components/drd/Core/Src/external_lights.c
+++ b/components/drd/Core/Src/external_lights.c
@@ -56,16 +56,13 @@ void ExternalLights_state_machine()
 
 		flash_count++;
 
-		// if (flash_count >= LIGHTS_FLIP_COUNT)
-		// {
-		// 	flash_count = 0;
-		// 	lts = !lts;
-		// 	rts = !rts;
-		// }
-        flash_count = 0;
-        lts = !lts;
-        rts = !rts;
-        
+		if (flash_count >= LIGHTS_FLIP_COUNT)
+		{
+			flash_count = 0;
+			lts = !lts;
+			rts = !rts;
+		}
+
 		dtr = 0;
 		prev_state = HAZARD_STATE;
 	}


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
- some of the hazard light logic accidentally got commented out in Aarjav's latest commit. Quickly fixed by commenting it out. verified by testing on DRD>

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [x] DRD
- [ ] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [x] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [x] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->