### PR TITLE
FIX: DRD Command Message Flags Fix

### DIFF
--- a/components/drd/Core/Inc/drive_state.h
+++ b/components/drd/Core/Inc/drive_state.h
@@ -59,7 +59,7 @@ typedef struct{
 typedef struct {
 	uint16_t accel_DAC_value;
 	uint16_t regen_DAC_value;
-	uint8_t motor_command_flags; //break pressed first bit and eco mode value second bit.
+	uint8_t motor_command_flags; //direction value first bit and eco mode value second bit.
 } motor_command_t;
 
 typedef enum {

--- a/components/drd/Core/Src/drive_state.c
+++ b/components/drd/Core/Src/drive_state.c
@@ -425,7 +425,7 @@ void brake_press_handle()
 uint8_t get_command_flags()
 {
 	uint8_t flags = 0;
-	flags |= (input_flags.mech_brake_pressed ? 1: 0);
+	flags |= (drive_state == REVERSE  ? 0: 1); //direction value: 0 for reverse, 1 for forward or Park
 	flags |= (input_flags.eco_mode_on ? 1 << 1: 0);
 	return flags;
 }


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
- Changed the flags sent to be correct. Previously, I was sending mech brake pressed when I should have been sending a direction value. This has been fixed.

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DRD
- [ ] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->