### PR TITLE
Fix: Clear RCC_CSR Register

### DIFF
--- a/components/ecu/ecu_firmware/Core/Src/fsm.c
+++ b/components/ecu/ecu_firmware/Core/Src/fsm.c
@@ -50,6 +50,7 @@ void FSM_Init()
 
     if (reset_flags & RCC_CSR_IWDGRSTF) {
         // After we're done reading the RCC_CSR_IWDGRSTF flag, reset all flags. RCC_CSR reset bits keep their values until cleared.
+        // See Monday Update: https://ubcsolar26.monday.com/boards/7524367629/pulses/8628510380/posts/3952602594
         __HAL_RCC_CLEAR_RESET_FLAGS();
 
         //IWDG triggered

--- a/components/ecu/ecu_firmware/Core/Src/fsm.c
+++ b/components/ecu/ecu_firmware/Core/Src/fsm.c
@@ -53,13 +53,13 @@ void FSM_Init()
         printf("watchdog-triggered software reset \r\n");
         ecu_data.status.bits.reset_from_watchdog = 1; //CAN_message now knows watchdog event has occured
         FSM_state = FAULT;
-        
-        // After we're done reading the RCC_CSR_IWDGRSTF flag, reset all flags. RCC_CSR reset bits keep their values until cleared.
-        __HAL_RCC_CLEAR_RESET_FLAGS();
     }
     else {
         FSM_state = FSM_RESET;
     }
+        
+    // After we're done reading the RCC_CSR_IWDGRSTF flag, reset all flags. RCC_CSR reset bits keep their values until cleared.
+    __HAL_RCC_CLEAR_RESET_FLAGS();
 
     return;
 }

--- a/components/ecu/ecu_firmware/Core/Src/fsm.c
+++ b/components/ecu/ecu_firmware/Core/Src/fsm.c
@@ -54,7 +54,7 @@ void FSM_Init()
         ecu_data.status.bits.reset_from_watchdog = 1; //CAN_message now knows watchdog event has occured
         FSM_state = FAULT;
         
-        // After we're done reading the RCC_CSR_IWDGRSTF flag, reset all flags. This is a non-volatile register, so we have to reset after every power up.
+        // After we're done reading the RCC_CSR_IWDGRSTF flag, reset all flags. RCC_CSR reset bits keep their values until cleared.
         __HAL_RCC_CLEAR_RESET_FLAGS();
     }
     else {

--- a/components/ecu/ecu_firmware/Core/Src/fsm.c
+++ b/components/ecu/ecu_firmware/Core/Src/fsm.c
@@ -53,6 +53,9 @@ void FSM_Init()
         printf("watchdog-triggered software reset \r\n");
         ecu_data.status.bits.reset_from_watchdog = 1; //CAN_message now knows watchdog event has occured
         FSM_state = FAULT;
+        
+        // After we're done reading the RCC_CSR_IWDGRSTF flag, reset all flags. This is a non-volatile register, so we have to reset after every power up.
+        __HAL_RCC_CLEAR_RESET_FLAGS();
     }
     else {
         FSM_state = FSM_RESET;

--- a/components/ecu/ecu_firmware/Core/Src/fsm.c
+++ b/components/ecu/ecu_firmware/Core/Src/fsm.c
@@ -49,6 +49,9 @@ void FSM_Init()
     uint32_t reset_flags = RCC->CSR;
 
     if (reset_flags & RCC_CSR_IWDGRSTF) {
+        // After we're done reading the RCC_CSR_IWDGRSTF flag, reset all flags. RCC_CSR reset bits keep their values until cleared.
+        __HAL_RCC_CLEAR_RESET_FLAGS();
+
         //IWDG triggered
         printf("watchdog-triggered software reset \r\n");
         ecu_data.status.bits.reset_from_watchdog = 1; //CAN_message now knows watchdog event has occured
@@ -57,9 +60,6 @@ void FSM_Init()
     else {
         FSM_state = FSM_RESET;
     }
-        
-    // After we're done reading the RCC_CSR_IWDGRSTF flag, reset all flags. RCC_CSR reset bits keep their values until cleared.
-    __HAL_RCC_CLEAR_RESET_FLAGS();
 
     return;
 }


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
We clear the RCC_CSR register after reading it and seeing the IWDG was triggered. Without clearing, the bit that represents an IWDG-triggered reset would always be high and we'd go into a fault on every startup of the ECU into eternity.

## Monday Link
[<!-- Copy related Monday issue here -->](https://ubcsolar26.monday.com/boards/7524367629/pulses/8628510380/posts/3952602594)

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DRD
- [X] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [X] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [X] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->