### PR TITLE
Fix: LVS Current Sensor Formula

### DIFF
--- a/components/ecu/ecu_firmware/Core/Src/adc.c
+++ b/components/ecu/ecu_firmware/Core/Src/adc.c
@@ -57,7 +57,8 @@ void ADC_setReading(float adc_reading, adc_channel_list adc_channel)
     break;
   
   case LVS_CURRENT_SENSE__ADC1_IN9: // LVS current supplied to HVDCDC (mA)
-    ecu_data.adc_data.ADC_lvs_current = (uint16_t)((adc_voltage-ecu_data.adc_data.ADC_lvs_current_sense_offset)/25.25);
+    // -1mV is from characterization [LINK MONDAY UPDATE], /25 is sensitivity value from datasheet, *1000 is A to mA
+    ecu_data.adc_data.ADC_lvs_current = (uint16_t)((adc_voltage-ecu_data.adc_data.ADC_lvs_current_sense_offset-1)/25*1000); // See datasheet: https://www.melexis.com/-/media/files/documents/datasheets/mlx91221-datasheet-melexis.pdf
     break;
   
   case PACK_CURRENT_SENSE__ADC1_IN14: // Pack current sense (mA)

--- a/components/ecu/ecu_firmware/Core/Src/adc.c
+++ b/components/ecu/ecu_firmware/Core/Src/adc.c
@@ -57,7 +57,7 @@ void ADC_setReading(float adc_reading, adc_channel_list adc_channel)
     break;
   
   case LVS_CURRENT_SENSE__ADC1_IN9: // LVS current supplied to HVDCDC (mA)
-    // -1mV is from characterization [LINK MONDAY UPDATE], /25 is sensitivity value from datasheet, *1000 is A to mA
+    // -1mV is from characterization (https://ubcsolar26.monday.com/boards/7524367629/pulses/8628510380), /25 is sensitivity value from datasheet, *1000 is A to mA
     ecu_data.adc_data.ADC_lvs_current = (uint16_t)((adc_voltage-ecu_data.adc_data.ADC_lvs_current_sense_offset-1)/25*1000); // See datasheet: https://www.melexis.com/-/media/files/documents/datasheets/mlx91221-datasheet-melexis.pdf
     break;
   


### PR DESCRIPTION
## Pull Request Description
The previous formula for the LVS current sensor outputted in amps. We need the value in mA. Because our value was 1000x lower than expected, it was rounding to zero.

## Monday Link
[<!-- Copy related Monday issue here -->](https://ubcsolar26.monday.com/boards/7524367629/pulses/8628510380)

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [ ] DRD
- [X] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [X] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [X] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->