### PR TITLE
Refactor: DRD Turn Signal Function

### DIFF
--- a/components/drd/Core/Src/external_lights.c
+++ b/components/drd/Core/Src/external_lights.c
@@ -150,7 +150,7 @@ void External_Lights_set_turn_signals(uint32_t can_id, uint8_t* data)
 	uint8_t rts = (data[0] & 1);
 	uint8_t lts = (data[0] & (1 << 1));
 
-	if (rts & lts)
+	if (rts && lts)
 	{
 		//both signals are on, invalid state, set both to off
 		left_turn_signal = 0;

--- a/components/drd/Core/Src/external_lights.c
+++ b/components/drd/Core/Src/external_lights.c
@@ -142,28 +142,22 @@ void Set_ExternalLights(uint8_t dtr, uint8_t lts, uint8_t rts)
 //call this from CAN rx callback
 void External_Lights_set_turn_signals(uint32_t can_id, uint8_t* data)
 {
-
-
-	if (can_id == STR_CAN_MSG_ID)
+	if (can_id != STR_CAN_MSG_ID)
 	{
-		uint8_t rts = (data[0] & 1);
-		uint8_t lts = (data[0] & (1 << 1));
-
-		if (lts)
-		{
-			left_turn_signal = 1;
-			right_turn_signal = 0;
-		}
-		else if (rts)
-		{
-			right_turn_signal = 1;
-			left_turn_signal = 0;
-		}
-		else //neither the left or right turn signals are on.
-		{
-			left_turn_signal = 0;
-			right_turn_signal = 0;
-		}
+		return;
 	}
 
+	uint8_t rts = (data[0] & 1);
+	uint8_t lts = (data[0] & (1 << 1));
+
+	if (rts & lts)
+	{
+		//both signals are on, invalid state, set both to off
+		left_turn_signal = 0;
+		right_turn_signal = 0;
+		return;
+	}
+
+	right_turn_signal = rts;
+	left_turn_signal = lts;
 }


### PR DESCRIPTION
## Pull Request Description
Refactored the DRD turn signal CAN receive function to get rid of unneeded if statements. The functionality is identical.

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] AMB
- [ ] BMS
- [X] DRD
- [ ] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [X] N/A

Grok and Kyle said it was fine.

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->