### PR TITLE
Feat: Drive State Diagnostic Addition

### DIFF
--- a/components/drd/Core/Inc/can.h
+++ b/components/drd/Core/Inc/can.h
@@ -59,7 +59,7 @@ extern const CAN_TxHeaderTypeDef time_since_bootup_can_header;
 
 #define MDU_REQUEST_FRAME					0b111 //request frames 0, 1 and 2 (0th, 1st and 2nd bit)
 #define MDU_REQUEST_SIZE 					1
-#define DRD_DIAGNOSTIC_SIZE					5
+#define DRD_DIAGNOSTIC_SIZE					6
 #define TIME_SINCE_BOOTUP_CAN_DATA_LENGTH 	4
 
 /* USER CODE END Private defines */

--- a/components/drd/Core/Inc/diagnostic.h
+++ b/components/drd/Core/Inc/diagnostic.h
@@ -29,6 +29,7 @@ typedef struct {
 	volatile uint16_t raw_adc1;
 	volatile uint16_t raw_adc2;
 	DRD_flags_t flags;
+	volatile int drive_state_diagnostic;
 } DRD_diagnostic_t;
 
 

--- a/components/drd/Core/Inc/diagnostic.h
+++ b/components/drd/Core/Inc/diagnostic.h
@@ -29,7 +29,6 @@ typedef struct {
 	volatile uint16_t raw_adc1;
 	volatile uint16_t raw_adc2;
 	DRD_flags_t flags;
-	volatile uint8_t drive_state_diagnostic;
 } DRD_diagnostic_t;
 
 

--- a/components/drd/Core/Inc/diagnostic.h
+++ b/components/drd/Core/Inc/diagnostic.h
@@ -29,7 +29,7 @@ typedef struct {
 	volatile uint16_t raw_adc1;
 	volatile uint16_t raw_adc2;
 	DRD_flags_t flags;
-	volatile int drive_state_diagnostic;
+	volatile uint8_t drive_state_diagnostic;
 } DRD_diagnostic_t;
 
 

--- a/components/drd/Core/Src/diagnostic.c
+++ b/components/drd/Core/Src/diagnostic.c
@@ -38,7 +38,7 @@ void DRD_time_since_bootup()
  */
 void DRD_diagnostics_transmit(DRD_diagnostic_t* diagnostics, bool from_ISR)
 {
-	DRD_diagnostic_t g_diagnostics.drive_state_diagnostic = g_drive_state;
+	g_diagnostics.drive_state_diagnostic = g_drive_state;
 
 	CAN_comms_Tx_msg_t msg;
 	msg.header = drd_diagnostic_header;

--- a/components/drd/Core/Src/diagnostic.c
+++ b/components/drd/Core/Src/diagnostic.c
@@ -38,6 +38,8 @@ void DRD_time_since_bootup()
  */
 void DRD_diagnostics_transmit(DRD_diagnostic_t* diagnostics, bool from_ISR)
 {
+	DRD_diagnostic_t g_diagnostics.drive_state_diagnostic = g_drive_state;
+
 	CAN_comms_Tx_msg_t msg;
 	msg.header = drd_diagnostic_header;
 

--- a/components/drd/Core/Src/diagnostic.c
+++ b/components/drd/Core/Src/diagnostic.c
@@ -46,6 +46,7 @@ void DRD_diagnostics_transmit(DRD_diagnostic_t* diagnostics, bool from_ISR)
 	msg.data[2] = (diagnostics->raw_adc2 & 0xFF);
 	msg.data[3] = (diagnostics->raw_adc2 >> 8);
 	msg.data[4] =  diagnostics->flags.all_flags;
+	msg.data[5] = diagnostics->drive_state_diagnostic;
 
 	if (from_ISR)
 	{

--- a/components/drd/Core/Src/diagnostic.c
+++ b/components/drd/Core/Src/diagnostic.c
@@ -7,6 +7,7 @@
 
 /*	INCLUDES	*/
 #include "diagnostic.h"
+#include "drive_state.h"
 #include "CAN_comms.h"
 #include "can.h"
 
@@ -38,8 +39,6 @@ void DRD_time_since_bootup()
  */
 void DRD_diagnostics_transmit(DRD_diagnostic_t* diagnostics, bool from_ISR)
 {
-	g_diagnostics.drive_state_diagnostic = g_drive_state;
-
 	CAN_comms_Tx_msg_t msg;
 	msg.header = drd_diagnostic_header;
 
@@ -48,7 +47,7 @@ void DRD_diagnostics_transmit(DRD_diagnostic_t* diagnostics, bool from_ISR)
 	msg.data[2] = (diagnostics->raw_adc2 & 0xFF);
 	msg.data[3] = (diagnostics->raw_adc2 >> 8);
 	msg.data[4] =  diagnostics->flags.all_flags;
-	msg.data[5] = diagnostics->drive_state_diagnostic;
+	msg.data[5] = g_drive_state;
 
 	if (from_ISR)
 	{

--- a/components/drd/Core/Src/drive_state.c
+++ b/components/drd/Core/Src/drive_state.c
@@ -49,7 +49,7 @@ static uint16_t convert_to_dac(uint16_t adc);
 volatile uint32_t g_velocity_kmh = 0;
 volatile bool g_lcd_eco_mode_on = true;
 volatile drive_state_t g_drive_state = PARK;
-volatile DRD_diagnostic_t g_diagnostics.drive_state_diagnostic = 4;
+volatile DRD_diagnostic_t g_diagnostics.drive_state_diagnostic = 3;
 
 uint16_t g_throttle_DAC = 0;
 input_flags_t g_input_flags;
@@ -80,12 +80,12 @@ void Drive_State_Machine_handler()
 
 		case REVERSE:
 			motor_command = reverse_state_handle();
-			g_diagnostics.drive_state_diagnostic = 3;
+			g_diagnostics.drive_state_diagnostic = 4;
 		break;
 
 		case PARK:
 			motor_command = park_state_handle();
-			g_diagnostics.drive_state_diagnostic = 4;
+			g_diagnostics.drive_state_diagnostic = 3;
 		break;
 
 		default:

--- a/components/drd/Core/Src/drive_state.c
+++ b/components/drd/Core/Src/drive_state.c
@@ -49,6 +49,7 @@ static uint16_t convert_to_dac(uint16_t adc);
 volatile uint32_t g_velocity_kmh = 0;
 volatile bool g_lcd_eco_mode_on = true;
 volatile drive_state_t g_drive_state = PARK;
+volatile DRD_diagnostic_t g_diagnostics.drive_state_diagnostic = 4;
 
 uint16_t g_throttle_DAC = 0;
 input_flags_t g_input_flags;
@@ -74,14 +75,17 @@ void Drive_State_Machine_handler()
 	{
 		case FORWARD:
 			motor_command = forward_state_handle();
+			g_diagnostics.drive_state_diagnostic = 1;
 		break;
 
 		case REVERSE:
 			motor_command = reverse_state_handle();
+			g_diagnostics.drive_state_diagnostic = 3;
 		break;
 
 		case PARK:
 			motor_command = park_state_handle();
+			g_diagnostics.drive_state_diagnostic = 4;
 		break;
 
 		default:

--- a/components/drd/Core/Src/drive_state.c
+++ b/components/drd/Core/Src/drive_state.c
@@ -189,6 +189,7 @@ void handle_state_transition()
 			default:
 				g_drive_state = PARK;
 		}
+
 	//reset state transition requests
 	clear_request_flags();
 }

--- a/components/drd/Core/Src/drive_state.c
+++ b/components/drd/Core/Src/drive_state.c
@@ -49,7 +49,6 @@ static uint16_t convert_to_dac(uint16_t adc);
 volatile uint32_t g_velocity_kmh = 0;
 volatile bool g_lcd_eco_mode_on = true;
 volatile drive_state_t g_drive_state = PARK;
-volatile DRD_diagnostic_t g_diagnostics.drive_state_diagnostic = 3;
 
 uint16_t g_throttle_DAC = 0;
 input_flags_t g_input_flags;
@@ -75,17 +74,14 @@ void Drive_State_Machine_handler()
 	{
 		case FORWARD:
 			motor_command = forward_state_handle();
-			g_diagnostics.drive_state_diagnostic = 1;
 		break;
 
 		case REVERSE:
 			motor_command = reverse_state_handle();
-			g_diagnostics.drive_state_diagnostic = 4;
 		break;
 
 		case PARK:
 			motor_command = park_state_handle();
-			g_diagnostics.drive_state_diagnostic = 3;
 		break;
 
 		default:


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
Added the status for the drive state to the diagnostic message, with 1 being forward, 3 for park, and 4 for reverse.

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] BMS
- [X] DRD
- [ ] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [X] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->