### PR TITLE
flipped eco mode logic

### DIFF
--- a/components/drd/Core/Src/drive_state.c
+++ b/components/drd/Core/Src/drive_state.c
@@ -496,7 +496,7 @@ void velocity_CAN_msg_handle(uint8_t* data)
 void steering_CAN_msg_handle(uint8_t* data)
 {
     // If DRIVE MODE bit 3 is 1 then toggle eco_mode_on. Else do nothing
-	g_input_flags.eco_mode_on = (data[0] >> 2) ? !g_input_flags.eco_mode_on : g_input_flags.eco_mode_on; //third bit of steering CAN message
+	g_input_flags.eco_mode_on = (data[0] >> 2) ? g_input_flags.eco_mode_on : !g_input_flags.eco_mode_on; //third bit of steering CAN message
     
 	g_lcd_eco_mode_on = g_input_flags.eco_mode_on; //global variable for LCD
 }


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
Fixed eco mode bug causing the eco mode value to flip every time a steering wheel message is sent.

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] BMS
- [ ] DRD
- [ ] ECU
- [ ] MDI
- [X] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->