### PR TITLE
Fix: Supp ADC Voltage Reading

### DIFF
--- a/components/ecu/ecu_firmware/Core/Inc/adc.h
+++ b/components/ecu/ecu_firmware/Core/Inc/adc.h
@@ -29,7 +29,7 @@
 #define HASS100S_VOLTAGE_ERROR_TERM_CONSTANT -9 // (mV) subtract from ADC measurement of BATT_CURR_SENSE pin to get accurate current reading, see https://ubcsolar26.monday.com/boards/7524367629/pulses/7524367868
 #define HASS100S_VOLTAGE_ERROR_TERM_MULTIPLE -0.0000000288
 
-#define SUPP_VOLT_DIVIDER_SCALING 0.2249408050513023 //divide ADC reading by this value to get actual SUPP voltage
+#define SUPP_VOLT_DIVIDER_SCALING 0.2166666667 //divide ADC reading by this value to get actual SUPP voltage
 
 #define SUPP_BATT_VOLTAGE_DIVIDER 11.0
 #define ADC_VOLTAGE_SCALING 1000.0 // millivolts


### PR DESCRIPTION
## Pull Request Description
The constant describing the voltage divider on the supplemental battery to ADC line was incorrect.

## Monday Link
[<!-- Copy related Monday issue here -->](https://ubcsolar26.monday.com/boards/7524367629/pulses/9044731466/posts/4199430485)

## Effected Components
<!-- Check which components are affected -->
- [ ] BMS
- [ ] DRD
- [X] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [X] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [X] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->