### PR TITLE
Fix: Enable Battery Fans Before DCDC Swap

### DIFF
--- a/components/ecu/ecu_firmware/Core/Src/adc.c
+++ b/components/ecu/ecu_firmware/Core/Src/adc.c
@@ -64,6 +64,7 @@ void ADC_setReading(float adc_reading, adc_channel_list adc_channel)
   case PACK_CURRENT_SENSE__ADC1_IN14: // Pack current sense (mA)
     curr_voltage_error = HASS100S_VOLTAGE_ERROR_TERM_CONSTANT + (HASS100S_VOLTAGE_ERROR_TERM_MULTIPLE * adc_voltage); // Error Polynomial, See https://ubcsolar26.monday.com/boards/7524367629/pulses/7524367868/posts/3902002110
     ecu_data.adc_data.ADC_pack_current = (int32_t)(HASS100S_STD_DEV + HASS100S_INTERNAL_OFFSET + 100*(adc_voltage + curr_voltage_error - ecu_data.adc_data.ADC_pack_current_offset) / 0.625); //see HASS100-S datasheet
+    printf("ADC Pack Current: %d mA, ADC Voltage: %d, ADC bits: %d\r\n", ecu_data.adc_data.ADC_pack_current, adc_voltage, (int32_t)adc_reading);
     break;
 
   case T_AMBIENT_SENSE__ADC1_IN15: // Ambient controlboard temperature (deg C)

--- a/components/ecu/ecu_firmware/Core/Src/fsm.c
+++ b/components/ecu/ecu_firmware/Core/Src/fsm.c
@@ -465,7 +465,7 @@ void MDU_on()
  */
 void ECU_monitor()
 {
-    printf("Top of Monitoring\r\n");
+    //printf("Top of Monitoring\r\n");
 
     startup_complete = true; // Indicates all LV boards are up
 
@@ -556,7 +556,7 @@ void ECU_monitor()
  */
 void fault()
 {
-    printf("Top of Fault\r\n");
+    //printf("Top of Fault\r\n");
 
     /*************************
     Put Pack in Safe State

--- a/components/ecu/ecu_firmware/Core/Src/fsm.c
+++ b/components/ecu/ecu_firmware/Core/Src/fsm.c
@@ -88,9 +88,8 @@ void FSM_reset()
 {
     printf("Top of FSM reset\r\n");
 
-    //  Turn fans off
-    HAL_GPIO_WritePin(PACK_FANS_CTRL_GPIO_Port, PACK_FANS_CTRL_Pin, LOW);
-    HAL_GPIO_WritePin(MDU_FAN_CTRL_GPIO_Port, MDU_FAN_CTRL_Pin, LOW);
+    HAL_GPIO_WritePin(PACK_FANS_CTRL_GPIO_Port, PACK_FANS_CTRL_Pin, HIGH); // Enable pack fans before DCDC swap for the case of a fault during startup
+    HAL_GPIO_WritePin(MDU_FAN_CTRL_GPIO_Port, MDU_FAN_CTRL_Pin, LOW); // MDU fans not required to be enabled by regs
 
     // Open all contactors
     HAL_GPIO_WritePin(HLIM_CTRL_GPIO_Port, HLIM_CTRL_Pin, LOW);

--- a/components/ecu/ecu_firmware/ecu_firmware.ioc
+++ b/components/ecu/ecu_firmware/ecu_firmware.ioc
@@ -1,7 +1,7 @@
 #MicroXplorer Configuration settings - do not modify
-ADC1.AWD1HighThreshold=2710
+ADC1.AWD1HighThreshold=2725
 ADC1.AWD1ITMode=ENABLE
-ADC1.AWD1LowThreshold=2105
+ADC1.AWD1LowThreshold=2098
 ADC1.Channel-0\#ChannelRegularConversion=ADC_CHANNEL_5
 ADC1.Channel-1\#ChannelRegularConversion=ADC_CHANNEL_6
 ADC1.Channel-2\#ChannelRegularConversion=ADC_CHANNEL_7
@@ -331,6 +331,7 @@ PD2.Signal=UART5_RX
 PinOutPanel.RotationAngle=0
 ProjectManager.AskForMigrate=true
 ProjectManager.BackupPrevious=false
+ProjectManager.CompilerLinker=GCC
 ProjectManager.CompilerOptimize=6
 ProjectManager.ComputerToolchain=false
 ProjectManager.CoupleFile=false


### PR DESCRIPTION
## Pull Request Description
Currently fans do not turn on if the pack faults before we reach the DCDC_Swap state. This conflicts with what the regulations tell us to do, so this PR enables the fans in the FSM_Reset state.

![image](https://github.com/user-attachments/assets/a9fe9f19-4d3b-4f9f-9f5e-805481de883a)
![image](https://github.com/user-attachments/assets/0ac32532-ac31-4cb6-87b6-c86ce86a8bcb)

## Monday Link
N/A It's a small change, see the slack screenshots above.

## Effected Components
<!-- Check which components are affected -->
- [X] BMS
- [ ] DRD
- [X] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->